### PR TITLE
feat: support Firefox for Android (#16)

### DIFF
--- a/manifests/chrome.json
+++ b/manifests/chrome.json
@@ -24,7 +24,8 @@
     "keyword": "hh"
   },
   "action": {
-    "default_title": "HubHop Settings",
+    "default_title": "HubHop",
+    "default_popup": "popup/popup.html",
     "default_icon": {
       "16": "icons/icon16.png",
       "32": "icons/icon32.png",

--- a/manifests/firefox.json
+++ b/manifests/firefox.json
@@ -1,1 +1,54 @@
-{  "manifest_version": 3,  "name": "HubHop",  "version": "0.1.3",  "description": "Jump to any GitHub repo from the address bar. Type 'hh <repo>' and go.",  "permissions": [    "storage",    "alarms",    "tabs"  ],  "host_permissions": [    "https://github.com/*",    "https://api.github.com/*"  ],  "optional_host_permissions": [    "*://*/*"  ],  "background": {    "scripts": [      "background.js"    ]  },  "omnibox": {    "keyword": "hh"  },  "action": {    "default_title": "HubHop Settings",    "default_icon": "icons/icon.svg"  },  "options_ui": {    "page": "options/options.html",    "open_in_tab": true  },  "icons": {    "16": "icons/icon.svg",    "32": "icons/icon.svg",    "48": "icons/icon.svg",    "128": "icons/icon.svg"  },  "browser_specific_settings": {    "gecko": {      "id": "hubhop@stevenwolfe.dev",      "strict_min_version": "140.0",      "data_collection_permissions": {        "required": ["none"],        "optional": []      },      "android": true    }  }}
+{
+  "manifest_version": 3,
+  "name": "HubHop",
+  "version": "0.1.3",
+  "description": "Jump to any GitHub repo from the address bar. Type 'hh <repo>' and go.",
+  "permissions": [
+    "storage",
+    "alarms",
+    "tabs"
+  ],
+  "host_permissions": [
+    "https://github.com/*",
+    "https://api.github.com/*"
+  ],
+  "optional_host_permissions": [
+    "*://*/*"
+  ],
+  "background": {
+    "scripts": [
+      "background.js"
+    ]
+  },
+  "omnibox": {
+    "keyword": "hh"
+  },
+  "action": {
+    "default_title": "HubHop",
+    "default_icon": "icons/icon.svg",
+    "default_popup": "popup/popup.html"
+  },
+  "options_ui": {
+    "page": "options/options.html",
+    "open_in_tab": true
+  },
+  "icons": {
+    "16": "icons/icon.svg",
+    "32": "icons/icon.svg",
+    "48": "icons/icon.svg",
+    "128": "icons/icon.svg"
+  },
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "hubhop@stevenwolfe.dev",
+      "strict_min_version": "142.0",
+      "data_collection_permissions": {
+        "required": [
+          "none"
+        ],
+        "optional": []
+      },
+      "android": true
+    }
+  }
+}

--- a/src/background.js
+++ b/src/background.js
@@ -163,53 +163,49 @@ async function navigateTo(url, disposition) {
   }
 }
 
-// ── Omnibox ──────────────────────────────────────────────────────────────────
+// ── Omnibox (desktop only — not available on Firefox for Android) ─────────────
 
-chrome.omnibox.onInputChanged.addListener(async (text, suggest) => {
-  const repos = await getCachedRepos();
-  const matches = searchRepos(repos, text.trim());
+if (chrome.omnibox) {
+  chrome.omnibox.onInputChanged.addListener(async (text, suggest) => {
+    const repos = await getCachedRepos();
+    const matches = searchRepos(repos, text.trim());
 
-  if (!matches.length) {
-    suggest([{
-      content: text,
-      description: `Go to <url>github.com/${text}</url>`,
-    }]);
-    return;
-  }
+    if (!matches.length) {
+      suggest([{
+        content: text,
+        description: `Go to <url>github.com/${text}</url>`,
+      }]);
+      return;
+    }
 
-  suggest(matches.map(repo => ({
-    content: repo.full_name,
-    description: `<match>${repo.full_name}</match>` +
-      (repo.instance !== 'GitHub' ? ` <dim>· ${repo.instance}</dim>` : ''),
-  })));
-});
+    suggest(matches.map(repo => ({
+      content: repo.full_name,
+      description: `<match>${repo.full_name}</match>` +
+        (repo.instance !== 'GitHub' ? ` <dim>· ${repo.instance}</dim>` : ''),
+    })));
+  });
 
-chrome.omnibox.onInputEntered.addListener(async (text, disposition) => {
-  const settings = await getSettings();
-  const repos = await getCachedRepos();
-  const query = text.trim();
+  chrome.omnibox.onInputEntered.addListener(async (text, disposition) => {
+    const settings = await getSettings();
+    const repos = await getCachedRepos();
+    const query = text.trim();
 
-  const match = repos.find(r => r.full_name === query)
-    ?? repos.find(r => scoreRepo(r, query) > 0);
+    const match = repos.find(r => r.full_name === query)
+      ?? repos.find(r => scoreRepo(r, query) > 0);
 
-  let url;
-  if (match) {
-    const instance = instanceByName(settings, match.instance);
-    url = `${instance.url}/${match.full_name}`;
-  } else {
-    url = query.includes('/')
-      ? `https://github.com/${query}`
-      : `https://github.com/search?q=${encodeURIComponent(query)}&type=repositories`;
-  }
+    let url;
+    if (match) {
+      const instance = instanceByName(settings, match.instance);
+      url = `${instance.url}/${match.full_name}`;
+    } else {
+      url = query.includes('/')
+        ? `https://github.com/${query}`
+        : `https://github.com/search?q=${encodeURIComponent(query)}&type=repositories`;
+    }
 
-  await navigateTo(url, disposition);
-});
-
-// ── Toolbar icon → open options ──────────────────────────────────────────────
-
-chrome.action.onClicked.addListener(() => {
-  chrome.runtime.openOptionsPage();
-});
+    await navigateTo(url, disposition);
+  });
+}
 
 // ── Alarm-based refresh ──────────────────────────────────────────────────────
 

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -1,0 +1,114 @@
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+:root {
+  --bg: #0d1117;
+  --surface: #161b22;
+  --border: #30363d;
+  --text: #e6edf3;
+  --muted: #8b949e;
+  --accent: #2563eb;
+  --radius: 6px;
+  --font: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+  --mono: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+}
+
+body {
+  background: var(--bg);
+  color: var(--text);
+  font-family: var(--font);
+  font-size: 14px;
+  line-height: 1.5;
+  width: 320px;
+}
+
+#search-wrap {
+  padding: 10px;
+  border-bottom: 1px solid var(--border);
+}
+
+#search {
+  width: 100%;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--text);
+  font-family: var(--font);
+  font-size: 14px;
+  padding: 7px 10px;
+  outline: none;
+}
+
+#search:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.3);
+}
+
+#results {
+  list-style: none;
+  max-height: 280px;
+  overflow-y: auto;
+}
+
+#results li {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 9px 12px;
+  cursor: pointer;
+  border-bottom: 1px solid var(--border);
+  gap: 8px;
+}
+
+#results li:last-child { border-bottom: none; }
+
+#results li:hover { background: var(--surface); }
+
+#results li.empty {
+  cursor: default;
+  color: var(--muted);
+  font-size: 13px;
+  justify-content: center;
+  padding: 16px 12px;
+  text-align: center;
+}
+
+#results li.empty:hover { background: transparent; }
+
+.repo-name {
+  font-family: var(--mono);
+  font-size: 13px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+
+.repo-instance {
+  font-size: 11px;
+  color: var(--muted);
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+#footer {
+  border-top: 1px solid var(--border);
+  padding: 8px 10px;
+  display: flex;
+  justify-content: flex-end;
+}
+
+#settings-btn {
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--muted);
+  cursor: pointer;
+  font-family: var(--font);
+  font-size: 12px;
+  padding: 4px 10px;
+}
+
+#settings-btn:hover {
+  background: var(--border);
+  color: var(--text);
+}

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>HubHop</title>
+  <link rel="stylesheet" href="popup.css">
+</head>
+<body>
+  <div id="search-wrap">
+    <input id="search" type="text" placeholder="Search repos…" autocomplete="off" spellcheck="false">
+  </div>
+  <ul id="results"></ul>
+  <div id="footer">
+    <button id="settings-btn">Settings</button>
+  </div>
+  <script src="popup.js"></script>
+</body>
+</html>

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -1,0 +1,111 @@
+// HubHop popup — search UI for toolbar icon; primary interface on Firefox for Android
+
+const DEFAULT_INSTANCE_URL = 'https://github.com';
+
+function scoreRepo(repo, query) {
+  const name = repo.full_name.toLowerCase();
+  const q = query.toLowerCase();
+  if (name === q) return 3;
+  if (name.split('/')[1] === q) return 2;
+  if (name.includes(q)) return 1;
+  let qi = 0;
+  for (const c of name) {
+    if (c === q[qi]) qi++;
+    if (qi === q.length) return 0.5;
+  }
+  return 0;
+}
+
+function searchRepos(repos, query) {
+  if (!query.trim()) return repos.slice(0, 8);
+  return repos
+    .map(r => ({ repo: r, score: scoreRepo(r, query) }))
+    .filter(({ score }) => score > 0)
+    .sort((a, b) => b.score - a.score)
+    .slice(0, 8)
+    .map(({ repo }) => repo);
+}
+
+function instanceUrl(instances, instanceName) {
+  if (!instanceName || instanceName === 'GitHub') return DEFAULT_INSTANCE_URL;
+  return instances.find(i => i.name === instanceName)?.url ?? DEFAULT_INSTANCE_URL;
+}
+
+function navigate(url) {
+  chrome.tabs.update({ url });
+  window.close();
+}
+
+function renderResults(repos, instances, query) {
+  const list = document.getElementById('results');
+  list.innerHTML = '';
+
+  if (!repos.length) {
+    const li = document.createElement('li');
+    li.className = 'empty';
+    li.textContent = query.trim()
+      ? 'No matches'
+      : 'No repos cached — open Settings to pin orgs.';
+    list.appendChild(li);
+    return;
+  }
+
+  for (const repo of repos) {
+    const li = document.createElement('li');
+    const base = instanceUrl(instances, repo.instance);
+    const url = `${base}/${repo.full_name}`;
+
+    const nameSpan = document.createElement('span');
+    nameSpan.className = 'repo-name';
+    nameSpan.textContent = repo.full_name;
+    li.appendChild(nameSpan);
+
+    if (repo.instance && repo.instance !== 'GitHub') {
+      const instanceSpan = document.createElement('span');
+      instanceSpan.className = 'repo-instance';
+      instanceSpan.textContent = repo.instance;
+      li.appendChild(instanceSpan);
+    }
+
+    li.addEventListener('click', () => navigate(url));
+    list.appendChild(li);
+  }
+}
+
+async function main() {
+  const [{ repoCache: repos = [] }, { instances = [] }] = await Promise.all([
+    chrome.storage.local.get('repoCache'),
+    chrome.storage.sync.get({ instances: [] }),
+  ]);
+
+  const search = document.getElementById('search');
+
+  renderResults(searchRepos(repos, ''), instances, '');
+
+  search.addEventListener('input', () => {
+    renderResults(searchRepos(repos, search.value), instances, search.value);
+  });
+
+  search.addEventListener('keydown', e => {
+    if (e.key !== 'Enter') return;
+    const q = search.value.trim();
+    if (!q) return;
+    const match = repos.find(r => scoreRepo(r, q) > 0);
+    if (match) {
+      navigate(`${instanceUrl(instances, match.instance)}/${match.full_name}`);
+    } else {
+      navigate(q.includes('/')
+        ? `https://github.com/${q}`
+        : `https://github.com/search?q=${encodeURIComponent(q)}&type=repositories`);
+    }
+  });
+
+  document.getElementById('settings-btn').addEventListener('click', () => {
+    chrome.runtime.openOptionsPage();
+    window.close();
+  });
+
+  search.focus();
+}
+
+main();


### PR DESCRIPTION
Add a toolbar popup (src/popup/) as the primary search UI on Android,
where the omnibox API is unavailable. Guard omnibox listeners with a
`chrome.omnibox` feature check so the extension loads cleanly on Fenix.
Bump Firefox strict_min_version to 142.0 to satisfy the
data_collection_permissions field introduced in that Android release.

Closes #16

https://claude.ai/code/session_01VbAYChHyafGrPo4SV5pHop